### PR TITLE
Fix markdown typo to allow markdown preview as HTML

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,8 +98,8 @@ This instruction will send the `DownArrow` key to NVDA, wait for NVDA to send a 
 The last step is to close the NVDA connection and quit the screen reader:
 
 ```csharp
-			await NvdaDriver.DisconnectAsync();
-			```
+await NvdaDriver.DisconnectAsync();
+```
 
 This command will disconnect the remote control to NVDA, and then exit the screen reader.
 


### PR DESCRIPTION
Markdown code was broken since the closing code symbol was indented (I guess). 
This small fix allows the markdown to compile into HTML for reading preview.